### PR TITLE
Fix for three step Perceived Effort runs + add .gitignore file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Jetbrains
+.idea
+modules/
+*.swp
+
+# Config
+config.yaml
+
+# Generated files
+*.log
+taocalendar.html

--- a/trainaspower/trainasone.py
+++ b/trainaspower/trainasone.py
@@ -154,19 +154,29 @@ def convert_steps(steps, config: models.Config, perceived_effort: bool) -> Gener
                 # Provide a generous power range based on %CP for slower ranges
                 if step["targetType"] == "OPEN":
                     if perceived_effort:
-                        if step["stepOrder"] == 2:
-                            # Perceived effort warmup
-                            cp = get_critical_power()
-                            out_step.power_range = models.PowerRange(
-                                cp * 0.3, cp * 0.8)
-                        elif step["stepOrder"] == 3 and step["intensity"] not in recovery_step_types:
-                            # Perceived effort main body
-                            cp = get_critical_power()
-                            out_step.power_range = models.PowerRange(
-                                cp * 0.55, cp * 0.9)
+                        if len(steps) == 3:
+                            if step["stepOrder"] == 2:
+                                # Perceived effort main body
+                                cp = get_critical_power()
+                                out_step.power_range = models.PowerRange(
+                                    cp * 0.55, cp * 0.9)
+                            else:
+                                # Standing
+                                out_step.power_range = models.PowerRange(0, 50)
                         else:
-                            # Standing
-                            out_step.power_range = models.PowerRange(0, 50)
+                            if step["stepOrder"] == 2:
+                                # Perceived effort warmup
+                                cp = get_critical_power()
+                                out_step.power_range = models.PowerRange(
+                                    cp * 0.3, cp * 0.8)
+                            elif step["stepOrder"] == 3:
+                                # Perceived effort main body
+                                cp = get_critical_power()
+                                out_step.power_range = models.PowerRange(
+                                    cp * 0.55, cp * 0.9)
+                            else:
+                                # Standing
+                                out_step.power_range = models.PowerRange(0, 50)
                     elif step["intensity"] in recovery_step_types:
                         out_step.power_range = models.PowerRange(
                             0, get_critical_power() * 0.8)

--- a/trainaspower/trainasone.py
+++ b/trainaspower/trainasone.py
@@ -154,29 +154,21 @@ def convert_steps(steps, config: models.Config, perceived_effort: bool) -> Gener
                 # Provide a generous power range based on %CP for slower ranges
                 if step["targetType"] == "OPEN":
                     if perceived_effort:
-                        if len(steps) == 3:
-                            if step["stepOrder"] == 2:
-                                # Perceived effort main body
-                                cp = get_critical_power()
-                                out_step.power_range = models.PowerRange(
-                                    cp * 0.55, cp * 0.9)
-                            else:
-                                # Standing
-                                out_step.power_range = models.PowerRange(0, 50)
+                        # Some perceived effort workouts have a warmup
+                        if len(steps) > 3 and step["stepOrder"] == 2:
+                            # Perceived effort warmup
+                            cp = get_critical_power()
+                            out_step.power_range = models.PowerRange(
+                                cp * 0.3, cp * 0.8)
+                        # Penultimate step is always the main effort
+                        elif step["stepOrder"] == len(steps)-1:
+                            # Perceived effort main body
+                            cp = get_critical_power()
+                            out_step.power_range = models.PowerRange(
+                                cp * 0.55, cp * 0.9)
                         else:
-                            if step["stepOrder"] == 2:
-                                # Perceived effort warmup
-                                cp = get_critical_power()
-                                out_step.power_range = models.PowerRange(
-                                    cp * 0.3, cp * 0.8)
-                            elif step["stepOrder"] == 3:
-                                # Perceived effort main body
-                                cp = get_critical_power()
-                                out_step.power_range = models.PowerRange(
-                                    cp * 0.55, cp * 0.9)
-                            else:
-                                # Standing
-                                out_step.power_range = models.PowerRange(0, 50)
+                            # Perceived effort workouts start and end with a standing step
+                            out_step.power_range = models.PowerRange(0, 50)
                     elif step["intensity"] in recovery_step_types:
                         out_step.power_range = models.PowerRange(
                             0, get_critical_power() * 0.8)

--- a/trainaspower/trainasone.py
+++ b/trainaspower/trainasone.py
@@ -159,7 +159,7 @@ def convert_steps(steps, config: models.Config, perceived_effort: bool) -> Gener
                             cp = get_critical_power()
                             out_step.power_range = models.PowerRange(
                                 cp * 0.3, cp * 0.8)
-                        elif step["stepOrder"] == 3:
+                        elif step["stepOrder"] == 3 and step["intensity"] not in recovery_step_types:
                             # Perceived effort main body
                             cp = get_critical_power()
                             out_step.power_range = models.PowerRange(


### PR DESCRIPTION
As per Issue 27 https://github.com/gazpachoking/trainaspower/issues/27

Perceived Effort runs that only have three steps are not created properly:
Rather than **Stand, Run, Stand** they are created with the wrong power to be **Stand, Warmup, Run**

This PR updates to always create Perceived effort runs with 3 steps to be **Stand, Run, Stand**.

It also adds a .gitignore file

Perceived Effort run created wrongly
![image](https://github.com/gazpachoking/trainaspower/assets/8702450/b2331192-0697-4888-9a11-166a039d307f)

Corrected 3-step Perceived Effort Run
![image](https://github.com/gazpachoking/trainaspower/assets/8702450/6d0c58f0-1bea-47a8-af87-fe49c17bbfba)
