### PR TITLE
Fix date parsing with locked days in plan

### DIFF
--- a/trainaspower/trainasone.py
+++ b/trainaspower/trainasone.py
@@ -44,7 +44,7 @@ def get_next_workouts(config) -> Generator[models.Workout, None, None]:
         upcoming = r.html.find(".today, .future")
         for day in upcoming:
             if day.find(".workout"):
-                date = dateparser.parse(day.find(".title", first=True).text)
+                date = dateparser.parse(day.find(".title", first=True).text.splitlines()[-1])
                 workout_url = day.find(
                     ".workout a", first=True).absolute_links.pop()
                 yield get_workout(workout_url, date, config)


### PR DESCRIPTION
	- The .text of the day contains two lines if a day is locked in the training plan
		- Example: calendar_today lock 
		                  Sep 5
	- This commit fixes date parsing by removing the extra line